### PR TITLE
Fix/listbox height and backgrounds

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -2,12 +2,17 @@ import React from 'react';
 import { Button, Input, Listbox } from 'a11y-components';
 import 'a11y-components/dist/index.css';
 
+const testOptions = [];
+for (let i = 0; i < 100; i++) {
+  testOptions.push({ id: i, label: i });
+}
+
 const App = () => {
   return (
     <>
       <Button />
       <Input />
-      <Listbox />
+      <Listbox label="Lot's of stuff" options={testOptions} />
     </>
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amb-codes-crafts/a11y-components",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Made with create-react-library",
   "author": "ashleemboyer",
   "license": "MIT",

--- a/src/components/Listbox/Listbox.module.scss
+++ b/src/components/Listbox/Listbox.module.scss
@@ -1,3 +1,5 @@
+$option-height: 48;
+
 .Listbox {
   label {
     display: block;
@@ -28,7 +30,8 @@
   }
 
   ul {
-    max-height: 200px;
+    max-height: #{5 * $option-height}px;
+    overflow-y: scroll;
     border: 1px solid black;
     border-top-width: 0;
     list-style: none;
@@ -36,12 +39,13 @@
     margin: 0;
 
     li {
-      height: 48px;
+      height: #{$option-height}px;
       line-height: 48px;
       vertical-align: center;
       padding-left: 12px;
       padding-right: 12px;
       cursor: pointer;
+      background-color: white;
 
       &:hover:not([aria-selected='true']) {
         background-color: rgba(lightskyblue, 0.5);


### PR DESCRIPTION
# Overview

This PR sets fixes the `max-height` on the `Listbox` and sets `overflow-y` to `scroll`. It also sets the `background-color` to `white` on the `Listbox` options.

# Relevant issues

- fixes #5 Listbox doesn't have a max height or background color set on options

# Testing

Just make sure the tests and checks pass for now. I should probably get this set up for better testing. 🤔 